### PR TITLE
Fixed Keyboard Avoiding view and added a scroll view to correctly han…

### DIFF
--- a/screens/Group/JoinGroupScreen.js
+++ b/screens/Group/JoinGroupScreen.js
@@ -129,10 +129,8 @@ const JoinGroupScreen = (props) => {
   return (
     <SafeAreaView style={styles.screen}>
       <StatusBar style="light" />
-      <KeyboardAvoidingView 
-        behavior={Platform.OS === 'ios' ? 'position' : ''}
-      >
-        <ScrollView 
+      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : ''}>
+        <ScrollView
           style={styles.container}
           contentContainerStyle={styles.scroll}
         >
@@ -191,7 +189,7 @@ const styles = StyleSheet.create({
   },
 
   scroll: {
-    justifyContent: 'space-between'
+    justifyContent: 'space-between',
   },
 
   imageContainer: {


### PR DESCRIPTION
Hotfix for the Join Group screen. Fixed keyboard avoiding view according to the other screens. This could be revisited in the future for an app-wide solution for the same problem.